### PR TITLE
Add Polylang-aware alt text generation

### DIFF
--- a/.mago-stubs.php
+++ b/.mago-stubs.php
@@ -4,3 +4,14 @@
 // This file helps prevent false positives during analysis and is never loaded in production.
 
 define('WP_DEBUG', (bool) getenv('WP_DEBUG'));
+
+if (!function_exists('pll_get_post_language')) {
+    /**
+     * Polylang function stub for static analysis only.
+     *
+     * @return string|false
+     */
+    function pll_get_post_language(int $post_id, string $field = 'slug'): string|false {
+        return false;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ if (!$ability) {
 
 $result = $ability->execute([
     'attachment_id' => 456, // Required. Image attachment ID.
+    'context_post_id' => 123, // Optional. Uses this post's Polylang locale when available.
     'user_prompt' => 'Write the alt text in Polish.', // Optional. Extra AI instructions.
     'save' => false, // Optional. False returns only; true saves to attachment metadata. Default false.
 ]);
@@ -49,6 +50,11 @@ if (is_wp_error($result)) {
 $attachment_id = $result['attachment_id']; // 456
 $alt_text = $result['alt']; // Generated alt text.
 ```
+
+When Polylang is active, the editor automatically generates alt text in the
+current post's language. Outside the editor, the plugin checks the attachment's
+parent and then the attachment itself. Ability callers can provide
+`context_post_id` explicitly when an image is reused across translations.
 
 ### Filters
 
@@ -70,6 +76,25 @@ add_filter('acpl/ai_alt_generator/system_prompt', function($system_prompt, $atta
     // Modify the system prompt here
     return $system_prompt;
 }, 10, 4);
+```
+
+#### `acpl/ai_alt_generator/locale`
+
+Overrides the locale used to build the system prompt. The default is the
+current WordPress locale, or the relevant post locale when Polylang is active.
+
+**Parameters:**
+
+- `string $locale`
+- `int $attachment_id`
+- `int $context_post_id`
+
+**Usage:**
+
+```php
+add_filter('acpl/ai_alt_generator/locale', function($locale, $attachment_id, $context_post_id) {
+    return $locale;
+}, 10, 3);
 ```
 
 #### `acpl/ai_alt_generator/user_prompt`

--- a/includes/Abilities.php
+++ b/includes/Abilities.php
@@ -44,6 +44,13 @@ class Abilities {
                             'alt-text-generator-gpt-vision',
                         ),
                     ],
+                    'context_post_id' => [
+                        'type' => 'integer',
+                        'description' => __(
+                            'Optional post ID whose Polylang locale should be used for the generated alt text.',
+                            'alt-text-generator-gpt-vision',
+                        ),
+                    ],
                     'save' => [
                         'type' => 'boolean',
                         'default' => false,
@@ -85,13 +92,14 @@ class Abilities {
 
     private static function execute_generate_alt(array $args): array|WP_Error {
         $attachment_id = (int) $args['attachment_id'];
+        $context_post_id = (int) ($args['context_post_id'] ?? 0);
         $save_alt = !empty($args['save']);
         $user_prompt = (string) ($args['user_prompt'] ?? '');
 
         if ($save_alt) {
-            $alt_text = AltGenerator::generate_and_set_alt_text($attachment_id, $user_prompt);
+            $alt_text = AltGenerator::generate_and_set_alt_text($attachment_id, $user_prompt, $context_post_id);
         } else {
-            $alt_text = AltGenerator::generate_alt_text($attachment_id, $user_prompt);
+            $alt_text = AltGenerator::generate_alt_text($attachment_id, $user_prompt, $context_post_id);
         }
 
         if (is_wp_error($alt_text)) {

--- a/includes/AltGenerator.php
+++ b/includes/AltGenerator.php
@@ -5,7 +5,11 @@ namespace Acpl\AltGenerator;
 use WP_Error;
 
 class AltGenerator {
-    public static function generate_alt_text(int $attachment_id, string $user_prompt = ''): string|WP_Error {
+    public static function generate_alt_text(
+        int $attachment_id,
+        string $user_prompt = '',
+        int $context_post_id = 0,
+    ): string|WP_Error {
         if (!wp_attachment_is_image($attachment_id)) {
             return new WP_Error('not_an_image', __('Attachment ID is not an image.', 'alt-text-generator-gpt-vision'), [
                 'attachment_id' => $attachment_id,
@@ -18,7 +22,7 @@ class AltGenerator {
             $user_prompt = $options['default_user_prompt'];
         }
 
-        $locale = get_locale();
+        $locale = self::get_content_locale($attachment_id, $context_post_id);
         $language = (
             function_exists('locale_get_display_language') ? locale_get_display_language($locale, 'en') : $locale
         ) ?: $locale;
@@ -88,8 +92,12 @@ class AltGenerator {
         return $alt_text;
     }
 
-    public static function generate_and_set_alt_text(int $attachment_id, string $user_prompt = ''): string|WP_Error {
-        $alt_text = self::generate_alt_text($attachment_id, $user_prompt);
+    public static function generate_and_set_alt_text(
+        int $attachment_id,
+        string $user_prompt = '',
+        int $context_post_id = 0,
+    ): string|WP_Error {
+        $alt_text = self::generate_alt_text($attachment_id, $user_prompt, $context_post_id);
         if (is_wp_error($alt_text)) {
             AltGeneratorPlugin::error_log($alt_text);
 
@@ -98,6 +106,28 @@ class AltGenerator {
 
         update_post_meta($attachment_id, '_wp_attachment_image_alt', sanitize_text_field($alt_text));
         return $alt_text;
+    }
+
+    private static function get_content_locale(int $attachment_id, int $context_post_id): string {
+        $locale = get_locale();
+
+        if (function_exists('pll_get_post_language')) {
+            $post_ids = array_unique(array_filter([
+                $context_post_id,
+                wp_get_post_parent_id($attachment_id),
+                $attachment_id,
+            ]));
+
+            foreach ($post_ids as $post_id) {
+                $polylang_locale = pll_get_post_language((int) $post_id, 'locale');
+                if (is_string($polylang_locale) && $polylang_locale !== '') {
+                    $locale = $polylang_locale;
+                    break;
+                }
+            }
+        }
+
+        return (string) apply_filters('acpl/ai_alt_generator/locale', $locale, $attachment_id, $context_post_id);
     }
 
     public static function on_attachment_upload(array $metadata, int $attachment_id, string $context): array {

--- a/src/editor/components/GenerateAltButton.tsx
+++ b/src/editor/components/GenerateAltButton.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { update } from '@wordpress/icons';
@@ -23,6 +23,15 @@ export default ({
 }: GenerateAltButtonProps) => {
   const [isGenerating, setIsGenerating] = useState(false);
   const { createSuccessNotice, createErrorNotice } = useDispatch(noticesStore);
+  const contextPostId = useSelect(
+    (select) =>
+      (
+        select('core/editor') as unknown as {
+          getCurrentPostId: () => number;
+        }
+      ).getCurrentPostId(),
+    [],
+  );
 
   const handleClick = async () => {
     if (
@@ -44,6 +53,8 @@ export default ({
         imgId,
         saveAltInMediaLibrary,
         customPrompt,
+        undefined,
+        contextPostId,
       );
       onGenerate(alt);
 

--- a/src/utils/generateAltText.ts
+++ b/src/utils/generateAltText.ts
@@ -3,6 +3,7 @@ import { GENERATE_API_PATH } from '../constants';
 
 interface Input {
   attachment_id: number;
+  context_post_id?: number;
   save: boolean;
   user_prompt?: string;
 }
@@ -12,6 +13,7 @@ export default async (
   save: boolean = false,
   userPrompt?: string,
   signal?: AbortSignal | null,
+  contextPostId?: number,
 ) => {
   const input: Input = {
     attachment_id: attachmentId,
@@ -20,6 +22,10 @@ export default async (
 
   if (userPrompt?.length) {
     input.user_prompt = userPrompt;
+  }
+
+  if (contextPostId) {
+    input.context_post_id = contextPostId;
   }
 
   // Using apiFetch directly because `executeAbility` from `@wordpress/abilities` lacks `AbortSignal` support.


### PR DESCRIPTION
## Summary

- resolve the generated alt-text locale from Polylang when it is active
- pass the current editor post as context so reused images follow the active translation
- fall back through the attachment parent, attachment language, and WordPress locale
- expose an optional ability argument and a locale filter for non-editor integrations
- document the behavior and extension points

## Validation

- PHP syntax checks
- `composer format:check`
- `composer lint`
- `composer analyse`
- locale-priority behavior checks for context post, parent, attachment, and WordPress fallback
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run build`

Closes #11